### PR TITLE
elys changes - added cheat convertor

### DIFF
--- a/ACNHPokerCore/Main.Designer.cs
+++ b/ACNHPokerCore/Main.Designer.cs
@@ -1,4 +1,5 @@
-﻿namespace ACNHPokerCore
+﻿//modded by ELY M. 
+namespace ACNHPokerCore
 {
     partial class Main
     {
@@ -55,6 +56,8 @@
             this.OtherTabButton = new System.Windows.Forms.Button();
             this.InventoryTabButton = new System.Windows.Forms.Button();
             this.InventoryLargePanel = new System.Windows.Forms.Panel();
+            /* elys mod */
+            this.Converttocheat = new System.Windows.Forms.Button();
             this.SelectedItemName = new System.Windows.Forms.Label();
             this.RetainNameToggle = new JCS.ToggleSwitch();
             this.RetainNameLabel = new System.Windows.Forms.Label();
@@ -768,6 +771,8 @@
             // 
             // InventoryLargePanel
             // 
+            /* elys mod */
+            this.InventoryLargePanel.Controls.Add(this.Converttocheat);
             this.InventoryLargePanel.Controls.Add(this.SelectedItemName);
             this.InventoryLargePanel.Controls.Add(this.RetainNameToggle);
             this.InventoryLargePanel.Controls.Add(this.RetainNameLabel);
@@ -807,6 +812,24 @@
             this.InventoryLargePanel.Name = "InventoryLargePanel";
             this.InventoryLargePanel.Size = new System.Drawing.Size(1225, 550);
             this.InventoryLargePanel.TabIndex = 18;
+            /* elys mod */
+            // 
+            // Converttocheat
+            // 
+            this.Converttocheat.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(114)))), ((int)(((byte)(137)))), ((int)(((byte)(218)))));
+            this.Converttocheat.FlatAppearance.BorderSize = 0;
+            this.Converttocheat.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.Converttocheat.Font = new System.Drawing.Font("Arial", 9.75F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.Converttocheat.ForeColor = System.Drawing.Color.White;
+            this.Converttocheat.Location = new System.Drawing.Point(1039, 492);
+            this.Converttocheat.Name = "Converttocheat";
+            this.Converttocheat.Size = new System.Drawing.Size(163, 22);
+            this.Converttocheat.TabIndex = 36;
+            this.Converttocheat.Tag = "";
+            this.Converttocheat.Text = "Convert to Cheat Txt";
+            this.Converttocheat.TextAlign = System.Drawing.ContentAlignment.TopCenter;
+            this.Converttocheat.UseVisualStyleBackColor = false;
+            this.Converttocheat.Click += new System.EventHandler(this.Converttocheat_Click);
             // 
             // SelectedItemName
             // 
@@ -7552,5 +7575,7 @@
         private AutocompleteMenuNS.AutocompleteMenu VillagerAutoCompleteMenu;
         private System.Windows.Forms.Button CheckStateButton;
         private System.Windows.Forms.Button VersionButton;
+        /* elys mod */
+        private System.Windows.Forms.Button Converttocheat;
     }
 }

--- a/ACNHPokerCore/Main.cs
+++ b/ACNHPokerCore/Main.cs
@@ -1,4 +1,5 @@
-﻿using NAudio.Wave;
+﻿//Modded by ELY M.
+using NAudio.Wave;
 using System;
 using System.Collections.Generic;
 using System.Configuration;
@@ -114,6 +115,9 @@ namespace ACNHPokerCore
         private void Main_Load(object sender, EventArgs e)
         {
             this.Text = version;
+
+            //elys mod
+            this.Icon = Properties.Resources.NewLeaf;
 
             this.IPAddressInputBox.Text = ConfigurationManager.AppSettings["ipAddress"];
             IPAddressInputBox.SelectionAlignment = HorizontalAlignment.Center;
@@ -7782,5 +7786,190 @@ namespace ACNHPokerCore
                 Thread.Sleep(2000);
             } while (true);
         }
+
+
+
+        private void Converttocheat_Click(object sender, EventArgs e)
+        {
+
+            StringBuilder cheatmaker = new StringBuilder();
+
+            uint n1 = Utilities.GetItemSlotUIntAddress(1);
+            uint n2 = Utilities.GetItemSlotUIntAddress(2);
+            uint n3 = Utilities.GetItemSlotUIntAddress(3);
+            uint n4 = Utilities.GetItemSlotUIntAddress(4);
+            uint n5 = Utilities.GetItemSlotUIntAddress(5);
+            uint n6 = Utilities.GetItemSlotUIntAddress(6);
+            uint n7 = Utilities.GetItemSlotUIntAddress(7);
+            uint n8 = Utilities.GetItemSlotUIntAddress(8);
+            uint n9 = Utilities.GetItemSlotUIntAddress(9);
+            uint n10 = Utilities.GetItemSlotUIntAddress(10);
+            uint n11 = Utilities.GetItemSlotUIntAddress(11);
+            uint n12 = Utilities.GetItemSlotUIntAddress(12);
+            uint n13 = Utilities.GetItemSlotUIntAddress(13);
+            uint n14 = Utilities.GetItemSlotUIntAddress(14);
+            uint n15 = Utilities.GetItemSlotUIntAddress(15);
+            uint n16 = Utilities.GetItemSlotUIntAddress(16);
+            uint n17 = Utilities.GetItemSlotUIntAddress(17);
+            uint n18 = Utilities.GetItemSlotUIntAddress(18);
+            uint n19 = Utilities.GetItemSlotUIntAddress(19);
+            uint n20 = Utilities.GetItemSlotUIntAddress(20);
+            uint n21 = Utilities.GetItemSlotUIntAddress(21);
+            uint n22 = Utilities.GetItemSlotUIntAddress(22);
+            uint n23 = Utilities.GetItemSlotUIntAddress(23);
+            uint n24 = Utilities.GetItemSlotUIntAddress(24);
+            uint n25 = Utilities.GetItemSlotUIntAddress(25);
+            uint n26 = Utilities.GetItemSlotUIntAddress(26);
+            uint n27 = Utilities.GetItemSlotUIntAddress(27);
+            uint n28 = Utilities.GetItemSlotUIntAddress(28);
+            uint n29 = Utilities.GetItemSlotUIntAddress(29);
+            uint n30 = Utilities.GetItemSlotUIntAddress(30);
+            uint n31 = Utilities.GetItemSlotUIntAddress(31);
+            uint n32 = Utilities.GetItemSlotUIntAddress(32);
+            uint n33 = Utilities.GetItemSlotUIntAddress(33);
+            uint n34 = Utilities.GetItemSlotUIntAddress(34);
+            uint n35 = Utilities.GetItemSlotUIntAddress(35);
+            uint n36 = Utilities.GetItemSlotUIntAddress(36);
+            uint n37 = Utilities.GetItemSlotUIntAddress(37);
+            uint n38 = Utilities.GetItemSlotUIntAddress(38);
+            uint n39 = Utilities.GetItemSlotUIntAddress(39);
+            uint n40 = Utilities.GetItemSlotUIntAddress(40);
+
+
+            //Thank you to the code in Utilities.cs for auto updating offests for the cheat convertor.  
+            //ELY M.  
+
+string[] offsets = {
+"08100000 "+n1.ToString("X"),
+"08100000 "+n2.ToString("X"),
+"08100000 "+n3.ToString("X"),
+"08100000 "+n4.ToString("X"),
+"08100000 "+n5.ToString("X"),
+"08100000 "+n6.ToString("X"),
+"08100000 "+n7.ToString("X"),
+"08100000 "+n8.ToString("X"),
+"08100000 "+n9.ToString("X"),
+"08100000 "+n10.ToString("X"),
+"08100000 "+n11.ToString("X"),
+"08100000 "+n12.ToString("X"),
+"08100000 "+n13.ToString("X"),
+"08100000 "+n14.ToString("X"),
+"08100000 "+n15.ToString("X"),
+"08100000 "+n16.ToString("X"),
+"08100000 "+n17.ToString("X"),
+"08100000 "+n18.ToString("X"),
+"08100000 "+n19.ToString("X"),
+"08100000 "+n20.ToString("X"),
+"08100000 "+n21.ToString("X"),
+"08100000 "+n22.ToString("X"),
+"08100000 "+n23.ToString("X"),
+"08100000 "+n24.ToString("X"),
+"08100000 "+n25.ToString("X"),
+"08100000 "+n26.ToString("X"),
+"08100000 "+n27.ToString("X"),
+"08100000 "+n28.ToString("X"),
+"08100000 "+n29.ToString("X"),
+"08100000 "+n30.ToString("X"),
+"08100000 "+n31.ToString("X"),
+"08100000 "+n32.ToString("X"),
+"08100000 "+n33.ToString("X"),
+"08100000 "+n34.ToString("X"),
+"08100000 "+n35.ToString("X"),
+"08100000 "+n36.ToString("X"),
+"08100000 "+n37.ToString("X"),
+"08100000 "+n38.ToString("X"),
+"08100000 "+n39.ToString("X"),
+"08100000 "+n40.ToString("X"),
+
+};
+
+
+            try
+            {
+
+
+
+                cheatmaker.AppendLine("\n[Your Cheat Name Here]");
+
+                inventorySlot[] SlotPointer = new inventorySlot[40];
+                foreach (inventorySlot btn in this.InventoryPanel.Controls.OfType<inventorySlot>())
+                {
+                    int slotId = int.Parse(btn.Tag.ToString());
+                    SlotPointer[slotId - 1] = btn;
+                }
+                for (int i = 0; i < SlotPointer.Length; i++)
+                {
+
+                    string first = Utilities.precedingZeros(SlotPointer[i].getFlag1() + SlotPointer[i].getFlag2() + Utilities.precedingZeros(SlotPointer[i].fillItemID(), 4), 8);
+                    string second = Utilities.precedingZeros(SlotPointer[i].fillItemData(), 8);
+
+                    cheatmaker.AppendLine(offsets[i] + " " + second + " " + first);
+
+
+                    Debug.Print(first + " " + second + " " + SlotPointer[i].getFlag1() + " " + SlotPointer[i].getFlag2() + " " + SlotPointer[i].fillItemID());
+
+                }
+
+
+
+
+
+
+                //save to your own filename :)   
+                SaveFileDialog file = new SaveFileDialog()
+                {
+                    Filter = "Cheat Text (*.txt)|*.txt",
+                    //FileName = "items.nhi",
+                };
+
+                Configuration config = ConfigurationManager.OpenExeConfiguration(Application.ExecutablePath.Replace(".exe", ".dll"));
+
+                string savepath;
+
+                if (config.AppSettings.Settings["LastSave"].Value.Equals(string.Empty))
+                    savepath = Directory.GetCurrentDirectory() + @"\save";
+                else
+                    savepath = config.AppSettings.Settings["LastSave"].Value;
+
+                //Debug.Print(savepath);
+                if (Directory.Exists(savepath))
+                {
+                    file.InitialDirectory = savepath;
+                }
+                else
+                {
+                    file.InitialDirectory = @"C:\";
+                }
+
+                if (file.ShowDialog() != DialogResult.OK)
+                    return;
+
+                string[] temp = file.FileName.Split('\\');
+                string path = "";
+                for (int i = 0; i < temp.Length - 1; i++)
+                    path = path + temp[i] + "\\";
+
+                config.AppSettings.Settings["LastSave"].Value = path;
+                config.Save(ConfigurationSaveMode.Minimal);
+
+
+                //write to cheat//  
+                File.WriteAllText(file.FileName, cheatmaker.ToString());
+
+
+
+
+            }
+            catch (Exception ex)
+            {
+                MyLog.logEvent("MainForm", "Convert to Cheat txt: " + ex.Message.ToString());
+                MyMessageBox.Show(ex.Message.ToString(), "Convert to Cheat Crashed");
+            }
+        }
+        //end of elys mod  
+
+
+
+
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # ACNHPokerCore
 
+## Ely's Changes:   
+1. Added function to convert the inventory to cheat sheet txt.  
+2. Icon change to show that it is modded ACNHPoker - Not Official one.  
+	
 ![Release Image](https://i.ibb.co/txCNG22/131313.png)
 
    1. Spawns items for you on  Animal Crossing™: New Horizons using [sys-botbase](https://github.com/olliz0r/sys-botbase)


### PR DESCRIPTION
This is like the cheat generator at cheatsslips last year but you can make it in ACNHPoker :)  
The function is to make cheats txt.  I know cheats can not be used at same time with ACNHPoker Running.    
All you do is pick items and add it in the Inventory panel then use button "Convert to Cheats Txt Button" on bottom.     
I am often away from computer and I always use cheats txt in ACNH.    

Ignore changes I did in readme.md and icon change.   
it is for my repo.   


